### PR TITLE
feature: make menu bar icon fit macos theme

### DIFF
--- a/zmk-ble.xcodeproj/project.pbxproj
+++ b/zmk-ble.xcodeproj/project.pbxproj
@@ -362,8 +362,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/danielgindi/Charts.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				kind = exactVersion;
+				version = 4.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/zmk-ble/Assets.xcassets/zmk_logo.imageset/zmk_logo_small.svg
+++ b/zmk-ble/Assets.xcassets/zmk_logo.imageset/zmk_logo_small.svg
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24px" height="24px" viewBox="0 0 24 24" version="1.1">
-<defs>
-<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="0" y1="-0.19" x2="135.5" y2="135.32" >
-<stop offset="0" style="stop-color:rgb(0.784314%,43.529412%,77.254902%);stop-opacity:1;"/>
-<stop offset="1" style="stop-color:rgb(47.058824%,16.078431%,81.960784%);stop-opacity:1;"/>
-</linearGradient>
-<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="0" y1="-0.19" x2="135.5" y2="135.32" >
-<stop offset="0" style="stop-color:rgb(0.784314%,43.529412%,77.254902%);stop-opacity:1;"/>
-<stop offset="1" style="stop-color:rgb(47.058824%,16.078431%,81.960784%);stop-opacity:1;"/>
-</linearGradient>
-</defs>
 <g id="surface1">
-<path style="fill-rule:nonzero;fill:url(#linear0);stroke-width:0.15;stroke-linecap:round;stroke-linejoin:round;stroke:url(#linear1);stroke-miterlimit:4;" d="M 0 -0.198442 L 135.492049 -0.198442 L 135.492049 135.315656 L 0 135.315656 Z M 0 -0.198442 " transform="matrix(0.177161,0,0,0.177161,0,0)"/>
-<path style="fill:none;stroke-width:8.76;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:4;" d="M 53.513296 85.44047 L 53.513296 48.486089 L 67.757049 66.632542 L 81.956704 48.530187 L 81.956704 86.123994 M 15.500555 48.882974 L 37.637905 48.882974 L 16.316374 85.793257 L 36.844136 85.793257 M 98.559717 48.397892 L 98.559717 87.00596 " transform="matrix(0.177161,0,0,0.177161,0,0)"/>
-<path style="fill:none;stroke-width:8.76;stroke-linecap:round;stroke-linejoin:bevel;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:0;" d="M 119.859199 48.508138 L 101.536353 66.632542 L 119.969445 87.072108 " transform="matrix(0.177161,0,0,0.177161,0,0)"/>
+<path style="fill:none;stroke-width:8.76;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:4;" d="M 53.513296 85.44047 L 53.513296 48.486089 L 67.757049 66.632542 L 81.956704 48.530187 L 81.956704 86.123994 M 15.500555 48.882974 L 37.637905 48.882974 L 16.316374 85.793257 L 36.844136 85.793257 M 98.559717 48.397892 L 98.559717 87.00596 " transform="matrix(0.177161,0,0,0.177161,0,0)"/>
+<path style="fill:none;stroke-width:8.76;stroke-linecap:round;stroke-linejoin:bevel;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:0;" d="M 119.859199 48.508138 L 101.536353 66.632542 L 119.969445 87.072108 " transform="matrix(0.177161,0,0,0.177161,0,0)"/>
 </g>
 </svg>

--- a/zmk-ble/LineChartView.swift
+++ b/zmk-ble/LineChartView.swift
@@ -13,7 +13,6 @@ struct BatteryHistoryView: NSViewRepresentable {
     let entries: [HistoricalBatteryValue]
     func makeNSView(context: Context) -> LineChartView {
         let view = LineChartView()
-        view.backgroundColor = .white
         view.rightAxis.enabled = false
         view.rightAxis.axisMinimum = 0
         view.xAxis.drawLabelsEnabled = false

--- a/zmk-ble/zmk_bleApp.swift
+++ b/zmk-ble/zmk_bleApp.swift
@@ -20,7 +20,7 @@ class PeripheralDelegate : NSObject, CBPeripheralDelegate {
             peripheral.discoverCharacteristics([CBUUID(string: "2A19")], for: batteryService!)
         }
     }
-    
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         logger.info("didDiscoverCharacteristics")
         service.characteristics?.forEach({characteristics in
@@ -36,38 +36,41 @@ class PeripheralDelegate : NSObject, CBPeripheralDelegate {
         }
         let batteryLevel = firstByte
         print("battery level:", batteryLevel)
-        
+
     }
-    
+
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, CBCentralManagerDelegate {
     private let hidServiceUuid = CBUUID(string: "1812")
-    
+
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
-    
-    
+
+
     private var logger: Logger = Logger();
     private var peripheralDelegate: CBPeripheralDelegate = PeripheralDelegate()
     private var peripheral: CBPeripheral?
     private var zmkPeripheral: ZmkPeripheral?
-    
+
     private var cbManager: CBCentralManager?
 
-    
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
-            button.image = NSImage(named: "zmk_logo")
+            let statusItemImage = NSImage(named: "zmk_logo")
+            statusItemImage?.isTemplate = true
+
+            button.image = statusItemImage
             button.action = #selector(togglePopover)
         }
-        
+
         self.popover = NSPopover()
         self.popover.behavior = .transient
         self.cbManager = CBCentralManager(delegate: self, queue: nil)
     }
-    
+
     @objc func togglePopover() {
         if let button = statusItem.button {
             if popover.isShown {
@@ -77,7 +80,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CBCentralManagerDelegate {
             }
         }
     }
-    
+
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         logger.info("centralManagerDidUpdateState");
         logger.info("\(central.state.rawValue)");
@@ -92,13 +95,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, CBCentralManagerDelegate {
                 central.scanForPeripherals(withServices: [hidServiceUuid])
         }
     }
-    
+
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         logger.info("connected to \(peripheral.name!.description)")
         self.zmkPeripheral = ZmkPeripheral(cbPeripheral: peripheral, optionalZmkPeripheral: self.zmkPeripheral)
         self.popover.contentViewController = NSHostingController(rootView: ContentView(self.zmkPeripheral!))
     }
-    
+
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         logger.info("didDisconnectPeripheral")
         if self.peripheral == peripheral {
@@ -106,7 +109,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CBCentralManagerDelegate {
             central.scanForPeripherals(withServices: [hidServiceUuid])
         }
     }
-    
+
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
         logger.info("discovered \(peripheral)")
         central.stopScan()
@@ -119,7 +122,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CBCentralManagerDelegate {
 struct zmk_bleApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate;
 
-    
+
     var body: some Scene {
         // We don't need any windows, we want our app to be shown in the menubar only, see https://stackoverflow.com/questions/68305958/creating-a-macos-windowless-menu-bar-application-with-swiftui
         Settings {


### PR DESCRIPTION
Most MacOS icons are background-transparent, so this commit removes the
background of the icon svg and sets the image to be a template (so the
colors can be reversed)

imo this shouldn't be squash merged because the first commit updates the 
Charts dependency so it works with xcode 14